### PR TITLE
pin pragmas to 0.8.25

### DIFF
--- a/src/interfaces/IOptimismL1Block.sol
+++ b/src/interfaces/IOptimismL1Block.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.0;
 
 /// @custom:proxied
 /// @custom:predeploy 0x4200000000000000000000000000000000000015

--- a/src/mocks/TestERC20.sol
+++ b/src/mocks/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.0;
 
 import {MockERC20} from "forge-std/mocks/MockERC20.sol";
 

--- a/src/v1/Groth16Verifier.sol
+++ b/src/v1/Groth16Verifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.25;
 
 /// @title Groth16 verifier template.
 /// @author Remco Bloemen

--- a/src/v1/Groth16VerifierExtensions.sol
+++ b/src/v1/Groth16VerifierExtensions.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.25;
 
 import {Groth16Verifier} from "./Groth16Verifier.sol";
 import {isCDK} from "../utils/Constants.sol";

--- a/src/v1/LPNRegistryV1.sol
+++ b/src/v1/LPNRegistryV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {OwnableWhitelist} from "../utils/OwnableWhitelist.sol";
 import {Initializable} from

--- a/src/v1/QueryManager.sol
+++ b/src/v1/QueryManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {
     Groth16VerifierExtensions,

--- a/src/v1/RegistrationManager.sol
+++ b/src/v1/RegistrationManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {isEthereum, isOPStack, isMantle, isCDK} from "../utils/Constants.sol";
 import {IRegistrationManager} from "./interfaces/IRegistrationManager.sol";

--- a/src/v1/interfaces/IRegistrationManager.sol
+++ b/src/v1/interfaces/IRegistrationManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.0;
 
 /// @title IRegistrationManager
 /// @notice


### PR DESCRIPTION
Standard best practice with contracts is to keep pragmas pinned to a single compiler version whenever possible. The main exceptions are for interfaces and consumer facing inheritable contracts, where it's best to leave them open.

Our foundry config was set to [only use a single compiler version](https://github.com/Lagrange-Labs/lagrange-lpn-contracts/blob/383d432978e3693d3433b1ab0dedf6685db06608/foundry.toml#L8), `0.8.25`, so this PR actually has _no affect_ on the bytecode. But if we introduce other compilers in the future, this will ensure the compiler we test with & deployed with is the one we continue to use for the life span of v1 contracts.