### PR TITLE
Add support for limit, offset

### DIFF
--- a/src/v1/QueryManager.sol
+++ b/src/v1/QueryManager.sol
@@ -88,8 +88,19 @@ contract QueryManager is IQueryManager {
         bytes32[] calldata placeholders,
         uint256 startBlock,
         uint256 endBlock
+    ) external payable returns (uint256) {
+        return request(queryHash, placeholders, startBlock, endBlock, 0, 0);
+    }
+
+    function request(
+        bytes32 queryHash,
+        bytes32[] calldata placeholders,
+        uint256 startBlock,
+        uint256 endBlock,
+        uint32 limit,
+        uint32 offset
     )
-        external
+        public
         payable
         requireGasFee
         validateQueryRange(startBlock, endBlock)
@@ -110,10 +121,8 @@ contract QueryManager is IQueryManager {
 
         requests[requestId] = QueryRequest({
             input: QueryInput({
-                // TODO:
-                limit: 0,
-                // TODO:
-                offset: 0,
+                limit: limit,
+                offset: offset,
                 minBlockNumber: uint64(startBlock),
                 maxBlockNumber: uint64(endBlock),
                 blockHash: blockHash,

--- a/src/v1/client/LPNQueryV1.sol
+++ b/src/v1/client/LPNQueryV1.sol
@@ -70,10 +70,12 @@ contract LPNQueryV1 is LPNClientV1, Initializable {
         bytes32 queryHash,
         bytes32[] calldata placeholders,
         uint256 startBlock,
-        uint256 endBlock
+        uint256 endBlock,
+        uint32 limit,
+        uint32 offset
     ) external payable {
         uint256 requestId = lpnRegistry.request{value: lpnRegistry.gasFee()}(
-            queryHash, placeholders, startBlock, endBlock
+            queryHash, placeholders, startBlock, endBlock, limit, offset
         );
 
         requests[requestId] = RequestMetadata({

--- a/src/v1/interfaces/IQueryManager.sol
+++ b/src/v1/interfaces/IQueryManager.sol
@@ -47,6 +47,23 @@ interface IQueryManager {
         uint256 endBlock
     ) external payable returns (uint256);
 
+    /// @notice Submits a new request to the registry.
+    /// @param queryHash The identifier of the SQL query associated with the request.
+    /// @param placeholders Values for the numbered placeholders in the query.
+    /// @param startBlock The starting block for the computation.
+    /// @param endBlock The ending block for the computation.
+    /// @param limit The maximum number of rows to return.
+    /// @param offset The number of rows to offset from the beginning.
+    /// @return ID The ID of the newly created request.
+    function request(
+        bytes32 queryHash,
+        bytes32[] calldata placeholders,
+        uint256 startBlock,
+        uint256 endBlock,
+        uint32 limit,
+        uint32 offset
+    ) external payable returns (uint256);
+
     /// @notice Submits a response to a specific request.
     /// @param requestId_ The ID of the request to respond to.
     /// @param data The proof, inputs, and public inputs to verify.

--- a/test/v1/LPNRegistryV1.t.sol
+++ b/test/v1/LPNRegistryV1.t.sol
@@ -167,6 +167,13 @@ contract LPNRegistryV1Test is Test {
             QUERY_HASH, PLACEHOLDERS, TEST_START_BLOCK, TEST_END_BLOCK
         );
         assertNotEq(id, id2);
+        // make request with explicit limit / offset (this is a different function)
+        uint256 id3 = registry.request{value: FEE}(
+            QUERY_HASH, PLACEHOLDERS, TEST_START_BLOCK, TEST_END_BLOCK, 10, 100
+        );
+        (, input) = registry.requests(id3);
+        assertEq(input.limit, 10);
+        assertEq(input.offset, 100);
     }
 
     function test_request_insufficientGasFee_reverts() public {


### PR DESCRIPTION
Adds support for limit & offset in `LPNQueryV1` and `LPNRegistryV1`. There are no tests yet, would prefer to merge after [this](https://github.com/Lagrange-Labs/lagrange-lpn-contracts/pull/46).