### PR TITLE
Add static analysis

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,0 +1,15 @@
+name: Slither
+
+on: push
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Slither
+        uses: crytic/slither-action@v0.4.0
+        id: slither
+        with:
+          fail-on: none # TODO - we should fail on any high findings, once existing ones are resolved

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ trace   :; forge test -vvv
 clean   :; forge clean
 snapshot:; forge snapshot
 fmt     :; forge fmt
+slither :; docker run -ti --entrypoint=/home/ethsec/.local/bin/slither -v ./:/local/ --workdir=/local trailofbits/eth-security-toolbox:nightly .
 
 # List available scripts
 list-scripts:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ $ forge test
 $ forge test -vvv
 ```
 
+## Run Static Analysis
+Requirements:
+  * docker
+
+```bash
+$ make slither
+```
+
 ## Makefile & Commands
 The commands in the [Makefile](./Makefile) are auto-generated based on:
 - the `*.s.sol` filenames under the [script](./script) directory

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,3 @@
+{
+    "filter_paths": "(lib/|script/|src/mocks|src/v0|test/)"
+}


### PR DESCRIPTION
This PR adds a make command to run [slither](https://github.com/crytic/slither) on the `v1/` contracts. It also adds slither to our CI. After the existing "high" findings are addressed, we can enforce that PRs cannot be merged with "high" findings present.