### PR TITLE
Make QueryManager and RegistrationManager abstract contracts

### DIFF
--- a/src/v1/QueryManager.sol
+++ b/src/v1/QueryManager.sol
@@ -14,7 +14,7 @@ import {IQueryManager} from "./interfaces/IQueryManager.sol";
 
 /// @title QueryManager
 /// @notice TODO
-contract QueryManager is IQueryManager {
+abstract contract QueryManager is IQueryManager {
     /// @notice The maximum number of blocks a query can be computed over
     uint256 public constant MAX_QUERY_RANGE = 50_000;
 

--- a/src/v1/RegistrationManager.sol
+++ b/src/v1/RegistrationManager.sol
@@ -6,7 +6,7 @@ import {IRegistrationManager} from "./interfaces/IRegistrationManager.sol";
 
 /// @title RegistrationManager
 /// @notice TODO
-contract RegistrationManager is IRegistrationManager {
+abstract contract RegistrationManager is IRegistrationManager {
     /// @notice Mapping to track registered tables
     mapping(bytes32 hash => bool registered) public tables;
 


### PR DESCRIPTION
These two contracts should never be deployed as standalone contracts - they are only used as dependancies of the `LPNRegistry` contract. Therefore, we mark them as abstract to prevent accidentally deploying them as standalone.