### PR TITLE
Refactor Verifier, VerifierExtension, and copy-verifier script

### DIFF
--- a/script/util/copy-verifier.sh
+++ b/script/util/copy-verifier.sh
@@ -1,30 +1,26 @@
 #! /bin/bash
+set -e
 
 GIT_REPO_PATH=../mapreduce-plonky2
 CODE_DIR_PATH=groth16-framework/test_data
 ENV=$1
 VERIFIER_FOLDER=./script/output/$1
-VERIFIER_FILE=$VERIFIER_FOLDER/Groth16Verifier.sol
-VERIFIER_EXTENSIONS_FILE=$VERIFIER_FOLDER/Groth16VerifierExtensions.sol
-#VERIFIER_SOL_URL="https://pub-64a4eb6e897e425083647b3e0e8539a1.r2.dev/groth16_assets/verifier.sol"
-
+VERIFIER_FILE=$VERIFIER_FOLDER/Verifier.sol.ignore
+VERIFIER_EXTENSION_FILE=$VERIFIER_FOLDER/Groth16VerifierExtension.sol.ignore
+VERIFIER_EXTENSION_URL=https://raw.githubusercontent.com/Lagrange-Labs/mapreduce-plonky2/refs/heads/main/groth16-framework/test_data/Groth16VerifierExtension.sol
 
 case "$ENV" in
   dev-0)
     VERIFIER_SOL_URL="https://pub-64a4eb6e897e425083647b3e0e8539a1.r2.dev"
-    BRANCH=holesky
     ;;
   dev-1)
     VERIFIER_SOL_URL="https://pub-a894572689a54c008859f232868fc67d.r2.dev"
-    BRANCH=holesky
     ;;
   dev-3)
     VERIFIER_SOL_URL="https://pub-bca6985bd0e849b5b8840edc0b7f9e15.r2.dev"
-    BRANCH=holesky
     ;;
   test)
     VERIFIER_SOL_URL="https://pub-fbb5db8dc9ee4e8da9daf13e07d27c24.r2.dev"
-    BRANCH=holesky
     ;;
   *)
     echo "Usage: $0 {dev-x|test}"
@@ -32,71 +28,25 @@ case "$ENV" in
     ;;
 esac
 
-echo "VERIFIER_SOL_URL: $VERIFIER_SOL_URL"
-
 VERIFIER_SOL_URL="$VERIFIER_SOL_URL/groth16_assets/verifier.sol"
-
-cd $GIT_REPO_PATH && \
-    git fetch origin $BRANCH && \
-    git checkout $BRANCH && \
-    git pull origin $BRANCH && \
-    cd -
 
 mkdir -p $VERIFIER_FOLDER
 
 wget -O $VERIFIER_FILE $VERIFIER_SOL_URL
-cp "${GIT_REPO_PATH}/${CODE_DIR_PATH}/Groth16VerifierExtensions.sol" $VERIFIER_EXTENSIONS_FILE
+wget -O $VERIFIER_EXTENSION_FILE $VERIFIER_EXTENSION_URL
 
-# Use awk for the following transformations
-awk '{
-  # Use as library instead of contract
-  gsub(/contract Verifier/, "library Groth16Verifier");
-
-  # Use internal instead of public functions
-  gsub(/public view/, "internal view");
-
-  # Read proof argument from memory instead of calldata
-  gsub(/calldata proof/, "memory proof");
-  gsub(/calldatacopy\(f, proof, 0x100\)/, "mstore(f, mload(add(proof, 0x00)))\nmstore(add(f, 0x20), mload(add(proof, 0x20)))\nmstore(add(f, 0x40), mload(add(proof, 0x40)))\nmstore(add(f, 0x60), mload(add(proof, 0x60)))\nmstore(add(f, 0x80), mload(add(proof, 0x80)))\nmstore(add(f, 0xa0), mload(add(proof, 0xa0)))\nmstore(add(f, 0xc0), mload(add(proof, 0xc0)))\nmstore(add(f, 0xe0), mload(add(proof, 0xe0)))");
-
-  # Read input argument from memory instead of calldata
-  gsub(/calldata input/, "memory input");
-  gsub(/calldataload\(input\)/, "mload(input)");
-  gsub(/calldataload\(add\(input, 32\)\)/, "mload(add(input, 32))");
-  gsub(/calldataload\(add\(input, 64\)\)/, "mload(add(input, 64))");
-
-  print;
-}' $VERIFIER_FILE > $VERIFIER_FILE.tmp && mv $VERIFIER_FILE.tmp $VERIFIER_FILE
-
+# TODO - remove all manual transformations... so close!
 awk '{
   # Import verifier library with renamed filename
-  gsub(/import {Verifier} from ".\/verifier.sol";/, "import {Groth16Verifier} from \".\/Groth16Verifier.sol\";\n   import {isCDK} from \"..\/utils\/Constants.sol\";");
-
-  # Use extensions as library instead of contract
-  gsub(/contract Query is Verifier {/, "library Groth16VerifierExtensions {");
-  gsub(/CIRCUIT_DIGEST/, "Groth16Verifier.CIRCUIT_DIGEST");
-  gsub(/this.verifyProof/, "Groth16Verifier.verifyProof");
-
-  # Use internal instead of public functions
-  gsub(/public view/, "internal view");
-
-  # Change "view" to "pure" in "function verifyQuery"
-  if (match($0, /function verifyQuery.*/)) {
-    sub(/pure/, "view"); 
-  }
+  gsub(/import {Verifier} from ".\/Verifier.sol";/, "import {Verifier} from \".\/Verifier.sol\";\n   import {isCDK} from \"..\/utils\/Constants.sol\";");
 
   # Patch `verifyQuery` function to skip blockhash verification for polygon CDK chains
-  gsub(/blockHash == query.blockHash/, "isCDK() || blockHash == query.blockHash");
+  gsub(/blockHash == expectedBlockHash/, "isCDK\(\) || blockHash == expectedBlockHash");
 
   print;
-}' $VERIFIER_EXTENSIONS_FILE > $VERIFIER_EXTENSIONS_FILE.tmp && mv $VERIFIER_EXTENSIONS_FILE.tmp $VERIFIER_EXTENSIONS_FILE
+}' $VERIFIER_EXTENSION_FILE > $VERIFIER_EXTENSION_FILE.tmp && mv $VERIFIER_EXTENSION_FILE.tmp $VERIFIER_EXTENSION_FILE
 
-
+cp $VERIFIER_EXTENSION_FILE ./src/v1/Groth16VerifierExtension.sol
+cp $VERIFIER_FILE ./src/v1/Verifier.sol
 
 forge fmt
-
-cp $VERIFIER_EXTENSIONS_FILE ./src/v1/Groth16VerifierExtensions.sol
-cp $VERIFIER_FILE ./src/v1/Groth16Verifier.sol
-
-mv $VERIFIER_EXTENSIONS_FILE $VERIFIER_EXTENSIONS_FILE.ignore
-mv $VERIFIER_FILE $VERIFIER_FILE.ignore

--- a/src/v1/QueryManager.sol
+++ b/src/v1/QueryManager.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.25;
 
 import {
-    Groth16VerifierExtensions,
+    Groth16VerifierExtension,
     QueryInput,
     QueryOutput
-} from "./Groth16VerifierExtensions.sol";
+} from "./Groth16VerifierExtension.sol";
 import {ILPNClientV1} from "./interfaces/ILPNClientV1.sol";
 import {isCDK} from "../utils/Constants.sol";
 import {L1BlockHash, L1BlockNumber} from "../utils/L1Block.sol";
@@ -14,7 +14,7 @@ import {IQueryManager} from "./interfaces/IQueryManager.sol";
 
 /// @title QueryManager
 /// @notice TODO
-abstract contract QueryManager is IQueryManager {
+abstract contract QueryManager is IQueryManager, Groth16VerifierExtension {
     /// @notice The maximum number of blocks a query can be computed over
     uint256 public constant MAX_QUERY_RANGE = 50_000;
 
@@ -146,8 +146,7 @@ abstract contract QueryManager is IQueryManager {
         QueryRequest memory query = requests[requestId_];
         delete requests[requestId_];
 
-        QueryOutput memory result =
-            Groth16VerifierExtensions.processQuery(data, query.input);
+        QueryOutput memory result = processQuery(data, query.input);
 
         ILPNClientV1(query.client).lpnCallback(requestId_, result);
 

--- a/src/v1/client/LPNClientV1.sol
+++ b/src/v1/client/LPNClientV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {ILPNClientV1} from "../interfaces/ILPNClientV1.sol";
 import {ILPNRegistryV1} from "../interfaces/ILPNRegistryV1.sol";
-import {QueryOutput} from "../Groth16VerifierExtensions.sol";
+import {QueryOutput} from "../Groth16VerifierExtension.sol";
 
 error CallbackNotAuthorized();
 

--- a/src/v1/client/LPNQueryV1.sol
+++ b/src/v1/client/LPNQueryV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import {LPNClientV1} from "./LPNClientV1.sol";
 import {ILPNRegistryV1} from "../interfaces/ILPNRegistryV1.sol";
-import {QueryOutput} from "../Groth16VerifierExtensions.sol";
+import {QueryOutput} from "../Groth16VerifierExtension.sol";
 import {Initializable} from
     "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/src/v1/client/SDK.sol
+++ b/src/v1/client/SDK.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {LPNClientV1} from "./LPNClientV1.sol";
 import {ILPNRegistryV1} from "../interfaces/ILPNRegistryV1.sol";
-import {QueryOutput, QueryErrorCode} from "../Groth16VerifierExtensions.sol";
+import {QueryOutput, QueryErrorCode} from "../Groth16VerifierExtension.sol";
 
 /// @dev Errors that occur while computing and proving the query result in the ZK Coprocessor
 error QueryExecutionError(QueryErrorCode errorCode);

--- a/src/v1/interfaces/ILPNClientV1.sol
+++ b/src/v1/interfaces/ILPNClientV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {QueryOutput} from "../Groth16VerifierExtensions.sol";
+import {QueryOutput} from "../Groth16VerifierExtension.sol";
 
 /**
  * @title ILPNClientV1

--- a/src/v1/interfaces/IQueryManager.sol
+++ b/src/v1/interfaces/IQueryManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {QueryOutput} from "../Groth16VerifierExtensions.sol";
+import {QueryOutput} from "../Groth16VerifierExtension.sol";
 
 /// @title IQueryManager
 /// @notice

--- a/src/v1/test_helpers/LPNRegistryV1TestHelper.sol
+++ b/src/v1/test_helpers/LPNRegistryV1TestHelper.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {LPNRegistryV1} from "../LPNRegistryV1.sol";
+import {QueryOutput, QueryInput} from "../Groth16VerifierExtension.sol";
+
+/// @title LPNRegistryV1TestHelper
+/// @notice A registry contract where groth-16 verification is skipped
+/// @dev XXX testing purposes only XXX
+/// @dev we want to mock as few functions as possible here to get us as close to the real deal as possible in testing
+contract LPNRegistryV1TestHelper is LPNRegistryV1 {
+    function processQuery(bytes32[] calldata data, QueryInput memory query)
+        public
+        view
+        override
+        returns (QueryOutput memory)
+    {}
+}


### PR DESCRIPTION
This PR does the following:
* Changes the 'Verifier' and `Groth16VerifierExtension` contracts to be directly inherited by the `LPNRegistry` rather than used as a library. This has several advantages:
  * When paired with [this change](https://github.com/Lagrange-Labs/mapreduce-plonky2/pull/414), verifier functions can be overwritten or modified based on the environment. This will make testing easier and will allow us to add chain specific modifications like skipping blockhash checks for polygon and scroll.
  * contracts can be consumed "as is" from the mp2 repo and don't need significant modifications from the `copy-verifier` script. This helps ensure that the contracts we test with are the same contracts we deploy to production.
  * This decreases the gas consumption by decreasing memory usage during verification
* Refactors the `copy-verifier` script to make the `Verifier` and `Groth16VerifierExtension` contracts match the changes introduced [here](https://github.com/Lagrange-Labs/mapreduce-plonky2/pull/414).
  * Renames `Groth16Verifer` to `Verifier` - this is done just so that contracts can be consumed "as is" from mp2 repo
  * Renames `Groth16VerifierExtensions` to `Groth16VerifierExtension` - this is just more idiomatic
  * Adds the `virtual` tag to several functions
* Creates a `LPNRegistryV1TestHelper` contract that allows us to mock the verification functions and test more of the response codepath. We should add more tests, but I didn't want to bloat this PR too much.

Note: the `copy-verifier.sh` script will require more changes once changes from [this PR](https://github.com/Lagrange-Labs/mapreduce-plonky2/pull/414) propagate through the system. Mostly deletions though! 😄 