### PR TITLE
Add chain support for scroll; remove codegen from copy-verifier.sh

### DIFF
--- a/script/util/copy-verifier.sh
+++ b/script/util/copy-verifier.sh
@@ -35,17 +35,6 @@ mkdir -p $VERIFIER_FOLDER
 wget -O $VERIFIER_FILE $VERIFIER_SOL_URL
 wget -O $VERIFIER_EXTENSION_FILE $VERIFIER_EXTENSION_URL
 
-# TODO - remove all manual transformations... so close!
-awk '{
-  # Import verifier library with renamed filename
-  gsub(/import {Verifier} from ".\/Verifier.sol";/, "import {Verifier} from \".\/Verifier.sol\";\n   import {isCDK} from \"..\/utils\/Constants.sol\";");
-
-  # Patch `verifyQuery` function to skip blockhash verification for polygon CDK chains
-  gsub(/blockHash == expectedBlockHash/, "isCDK\(\) || blockHash == expectedBlockHash");
-
-  print;
-}' $VERIFIER_EXTENSION_FILE > $VERIFIER_EXTENSION_FILE.tmp && mv $VERIFIER_EXTENSION_FILE.tmp $VERIFIER_EXTENSION_FILE
-
 cp $VERIFIER_EXTENSION_FILE ./src/v1/Groth16VerifierExtension.sol
 cp $VERIFIER_FILE ./src/v1/Verifier.sol
 

--- a/src/utils/Constants.sol
+++ b/src/utils/Constants.sol
@@ -93,6 +93,8 @@ function isMainnet() view returns (bool) {
     return chainMatches(mainnets);
 }
 
+/// @dev NOTE that Scroll plans to support blockhash verification in a future hardfork
+/// https://github.com/scroll-tech/scroll-contracts/issues/66
 function supportsL1Blockhash() view returns (bool) {
     uint256[3] memory noSupport =
         [POLYGON_ZKEVM_MAINNET, SCROLL_MAINNET, SCROLL_SEPOLIA];

--- a/src/utils/Constants.sol
+++ b/src/utils/Constants.sol
@@ -69,35 +69,30 @@ function isLocal() view returns (bool) {
 }
 
 function isTestnet() view returns (bool) {
-    uint256[5] memory testnets = [
+    uint256[6] memory testnets = [
         ETH_SEPOLIA,
         ETH_HOLESKY,
         BASE_SEPOLIA,
         FRAXTAL_HOLESKY,
-        MANTLE_SEPOLIA
+        MANTLE_SEPOLIA,
+        SCROLL_SEPOLIA
     ];
     return chainMatches(testnets);
 }
 
 function isMainnet() view returns (bool) {
-    uint256[5] memory mainnets = [
+    uint256[6] memory mainnets = [
         ETH_MAINNET,
         BASE_MAINNET,
         FRAXTAL_MAINNET,
         MANTLE_MAINNET,
-        POLYGON_ZKEVM_MAINNET
+        POLYGON_ZKEVM_MAINNET,
+        SCROLL_MAINNET
     ];
     return chainMatches(mainnets);
 }
 
-function chainMatches(uint256[4] memory chains) view returns (bool) {
-    for (uint256 i = 0; i < chains.length; i++) {
-        if (chains[i] == block.chainid) return true;
-    }
-    return false;
-}
-
-function chainMatches(uint256[5] memory chains) view returns (bool) {
+function chainMatches(uint256[6] memory chains) view returns (bool) {
     for (uint256 i = 0; i < chains.length; i++) {
         if (chains[i] == block.chainid) return true;
     }

--- a/src/utils/Constants.sol
+++ b/src/utils/Constants.sol
@@ -8,15 +8,25 @@ uint256 constant ETH_MAINNET = 1;
 uint256 constant ETH_SEPOLIA = 11155111;
 uint256 constant ETH_HOLESKY = 17000;
 
+// OP Stack Chains
+
 uint256 constant BASE_MAINNET = 8453;
 uint256 constant BASE_SEPOLIA = 84532;
 
 uint256 constant FRAXTAL_MAINNET = 252;
 uint256 constant FRAXTAL_HOLESKY = 2522;
 
-uint256 constant MANTLE_SEPOLIA = 5003;
 uint256 constant MANTLE_MAINNET = 5000;
+uint256 constant MANTLE_SEPOLIA = 5003;
+
+// Other Chains
+
 uint256 constant POLYGON_ZKEVM_MAINNET = 1101;
+
+uint256 constant SCROLL_MAINNET = 534352;
+uint256 constant SCROLL_SEPOLIA = 534351;
+
+// Addresses & constants
 
 address constant OP_STACK_L1_BLOCK_PREDEPLOY_ADDR =
     0x4200000000000000000000000000000000000015;
@@ -41,16 +51,9 @@ uint256 constant LAGRANGE_LOONS_LENGTH_SLOT = 8;
 
 uint256 constant TEST_ERC20_MAPPING_SLOT = 4;
 
-uint256 constant SCROLL_MAINNET = 534352;
-uint256 constant SCROLL_SEPOLIA = 534351;
-
 function isEthereum() view returns (bool) {
     return block.chainid == ETH_MAINNET || block.chainid == ETH_SEPOLIA
         || block.chainid == ETH_HOLESKY;
-}
-
-function isL2() view returns (bool) {
-    return isMantle() || isOPStack() || isCDK() || isScroll();
 }
 
 function isOPStack() view returns (bool) {
@@ -66,7 +69,7 @@ function isCDK() view returns (bool) {
 }
 
 function isMantle() view returns (bool) {
-    return block.chainid == MANTLE_MAINNET || block.chainid == MANTLE_MAINNET;
+    return block.chainid == MANTLE_MAINNET || block.chainid == MANTLE_SEPOLIA;
 }
 
 function isScroll() view returns (bool) {

--- a/src/utils/Constants.sol
+++ b/src/utils/Constants.sol
@@ -49,6 +49,10 @@ function isEthereum() view returns (bool) {
         || block.chainid == ETH_HOLESKY;
 }
 
+function isL2() view returns (bool) {
+    return isMantle() || isOPStack() || isCDK() || isScroll();
+}
+
 function isOPStack() view returns (bool) {
     uint32 size;
     assembly {
@@ -63,6 +67,10 @@ function isCDK() view returns (bool) {
 
 function isMantle() view returns (bool) {
     return block.chainid == MANTLE_MAINNET || block.chainid == MANTLE_MAINNET;
+}
+
+function isScroll() view returns (bool) {
+    return block.chainid == SCROLL_MAINNET || block.chainid == SCROLL_SEPOLIA;
 }
 
 function isLocal() view returns (bool) {
@@ -93,9 +101,9 @@ function isMainnet() view returns (bool) {
     return chainMatches(mainnets);
 }
 
-/// @dev NOTE that Scroll plans to support blockhash verification in a future hardfork
+/// @dev NOTE that Scroll plans to add blockhash/block number support in a future hardfork
 /// https://github.com/scroll-tech/scroll-contracts/issues/66
-function supportsL1Blockhash() view returns (bool) {
+function supportsL1BlockData() view returns (bool) {
     uint256[3] memory noSupport =
         [POLYGON_ZKEVM_MAINNET, SCROLL_MAINNET, SCROLL_SEPOLIA];
     return !chainMatches(noSupport);

--- a/src/utils/Constants.sol
+++ b/src/utils/Constants.sol
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
-
-import {IOptimismL1Block} from "../interfaces/IOptimismL1Block.sol";
+pragma solidity 0.8.25;
 
 uint256 constant LOCAL = 1337;
 uint256 constant ANVIL = 31337;
@@ -42,6 +40,9 @@ uint256 constant LAGRANGE_LOONS_MAPPING_SLOT = 2;
 uint256 constant LAGRANGE_LOONS_LENGTH_SLOT = 8;
 
 uint256 constant TEST_ERC20_MAPPING_SLOT = 4;
+
+uint256 constant SCROLL_MAINNET = 534352;
+uint256 constant SCROLL_SEPOLIA = 534351;
 
 function isEthereum() view returns (bool) {
     return block.chainid == ETH_MAINNET || block.chainid == ETH_SEPOLIA
@@ -90,6 +91,19 @@ function isMainnet() view returns (bool) {
         SCROLL_MAINNET
     ];
     return chainMatches(mainnets);
+}
+
+function supportsL1Blockhash() view returns (bool) {
+    uint256[3] memory noSupport =
+        [POLYGON_ZKEVM_MAINNET, SCROLL_MAINNET, SCROLL_SEPOLIA];
+    return !chainMatches(noSupport);
+}
+
+function chainMatches(uint256[3] memory chains) view returns (bool) {
+    for (uint256 i = 0; i < chains.length; i++) {
+        if (chains[i] == block.chainid) return true;
+    }
+    return false;
 }
 
 function chainMatches(uint256[6] memory chains) view returns (bool) {

--- a/src/utils/Constants.sol
+++ b/src/utils/Constants.sol
@@ -107,16 +107,7 @@ function isMainnet() view returns (bool) {
 /// @dev NOTE that Scroll plans to add blockhash/block number support in a future hardfork
 /// https://github.com/scroll-tech/scroll-contracts/issues/66
 function supportsL1BlockData() view returns (bool) {
-    uint256[3] memory noSupport =
-        [POLYGON_ZKEVM_MAINNET, SCROLL_MAINNET, SCROLL_SEPOLIA];
-    return !chainMatches(noSupport);
-}
-
-function chainMatches(uint256[3] memory chains) view returns (bool) {
-    for (uint256 i = 0; i < chains.length; i++) {
-        if (chains[i] == block.chainid) return true;
-    }
-    return false;
+    return isEthereum() || isOPStack();
 }
 
 function chainMatches(uint256[6] memory chains) view returns (bool) {

--- a/src/utils/L1Block.sol
+++ b/src/utils/L1Block.sol
@@ -20,7 +20,7 @@ function L1BlockHash() view returns (bytes32) {
         return IOptimismL1Block(OP_STACK_L1_BLOCK_PREDEPLOY_ADDR).hash();
     }
 
-    return bytes32(0); // TODO - we might want to revert here if we're on an unknown chain - "fail fast and loud"
+    return bytes32(0);
 }
 
 /// @notice The latest L1 block number.
@@ -36,5 +36,5 @@ function L1BlockNumber() view returns (uint256) {
             uint256(IOptimismL1Block(OP_STACK_L1_BLOCK_PREDEPLOY_ADDR).number());
     }
 
-    return 0; // TODO - we might want to revert here if we're on an unknown chain - "fail fast and loud"
+    return 0;
 }

--- a/src/utils/L1Block.sol
+++ b/src/utils/L1Block.sol
@@ -20,7 +20,7 @@ function L1BlockHash() view returns (bytes32) {
         return IOptimismL1Block(OP_STACK_L1_BLOCK_PREDEPLOY_ADDR).hash();
     }
 
-    return bytes32(0);
+    return bytes32(0); // TODO - we might want to revert here if we're on an unknown chain - "fail fast and loud"
 }
 
 /// @notice The latest L1 block number.
@@ -36,5 +36,5 @@ function L1BlockNumber() view returns (uint256) {
             uint256(IOptimismL1Block(OP_STACK_L1_BLOCK_PREDEPLOY_ADDR).number());
     }
 
-    return 0;
+    return 0; // TODO - we might want to revert here if we're on an unknown chain - "fail fast and loud"
 }

--- a/src/utils/L1Block.sol
+++ b/src/utils/L1Block.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {IOptimismL1Block} from "../interfaces/IOptimismL1Block.sol";
 import {

--- a/src/v1/Groth16VerifierExtension.sol
+++ b/src/v1/Groth16VerifierExtension.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.0;
 
 import {Verifier} from "./Verifier.sol";
-import {isCDK} from "../utils/Constants.sol";
 
 // The query input struct passed into the processQuery function
 struct QueryInput {
@@ -265,8 +264,7 @@ contract Groth16VerifierExtension is Verifier {
         virtual
     {
         require(
-            isCDK() || blockHash == expectedBlockHash,
-            "Block hash must equal as expected."
+            blockHash == expectedBlockHash, "Block hash must equal as expected."
         );
     }
 

--- a/src/v1/RegistrationManager.sol
+++ b/src/v1/RegistrationManager.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {isEthereum, isOPStack, isMantle, isCDK} from "../utils/Constants.sol";
 import {IRegistrationManager} from "./interfaces/IRegistrationManager.sol";
 
 /// @title RegistrationManager

--- a/src/v1/test_helpers/LPNRegistryV1TestHelper.sol
+++ b/src/v1/test_helpers/LPNRegistryV1TestHelper.sol
@@ -15,4 +15,12 @@ contract LPNRegistryV1TestHelper is LPNRegistryV1 {
         override
         returns (QueryOutput memory)
     {}
+
+    /// @notice exposes the verifyBlockHash function for testing (it is internal)
+    function testVerifyBlockhash(bytes32 blockHash, bytes32 expectedBlockHash)
+        public
+        view
+    {
+        verifyBlockHash(blockHash, expectedBlockHash);
+    }
 }

--- a/src/v1/test_helpers/LPNRegistryV1TestHelper.sol
+++ b/src/v1/test_helpers/LPNRegistryV1TestHelper.sol
@@ -17,10 +17,10 @@ contract LPNRegistryV1TestHelper is LPNRegistryV1 {
     {}
 
     /// @notice exposes the verifyBlockHash function for testing (it is internal)
-    function testVerifyBlockhash(bytes32 blockHash, bytes32 expectedBlockHash)
+    function verifyBlockhash(bytes32 blockHash, bytes32 expectedBlockHash)
         public
         view
     {
-        verifyBlockHash(blockHash, expectedBlockHash);
+        super.verifyBlockHash(blockHash, expectedBlockHash);
     }
 }

--- a/test/v1/BaseTest.t.sol
+++ b/test/v1/BaseTest.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {
+    isLocal,
+    isTestnet,
+    isMainnet,
+    isOPStack,
+    OP_STACK_L1_BLOCK_PREDEPLOY_ADDR,
+    BASE_MAINNET,
+    BASE_SEPOLIA,
+    FRAXTAL_MAINNET,
+    FRAXTAL_HOLESKY,
+    MANTLE_MAINNET,
+    MANTLE_SEPOLIA
+} from "../../src/utils/Constants.sol";
+
+abstract contract BaseTest is Test {
+    uint256 private nonce;
+
+    /// @notice Generates a random bytes32 value using an incrementing nonce
+    /// @dev Hashes the nonce value and increments it to ensure different values on each call
+    function randomBytes32() internal returns (bytes32) {
+        return keccak256(abi.encodePacked(++nonce));
+    }
+
+    /// @notice Imitates a chain by setting the chainID and deploying arbitrary bytecode to certain predeploys
+    function imitateChain(uint256 chainId) internal {
+        // validate the chainID is supported
+        if (!isLocal() && !isTestnet() && !isMainnet()) {
+            revert("Chain not supported");
+        }
+        // reset previouse imitations
+        vm.etch(OP_STACK_L1_BLOCK_PREDEPLOY_ADDR, hex"");
+        // imitate chain
+        vm.chainId(chainId);
+
+        if (_isOPStack(chainId)) {
+            vm.etch(OP_STACK_L1_BLOCK_PREDEPLOY_ADDR, hex"00");
+        }
+    }
+
+    /// @dev this is a brute-force implementation of isOPStack from Constants.sol
+    /// we need this in tests because OP_STACK_L1_BLOCK_PREDEPLOY_ADDR doesn't exist on the test chain
+    function _isOPStack(uint256 chainId) private view returns (bool) {
+        uint256[6] memory OPChains = [
+            BASE_MAINNET,
+            BASE_SEPOLIA,
+            FRAXTAL_MAINNET,
+            FRAXTAL_HOLESKY,
+            MANTLE_MAINNET,
+            MANTLE_SEPOLIA
+        ];
+        for (uint256 i = 0; i < OPChains.length; i++) {
+            if (OPChains[i] == chainId) return true;
+        }
+        return false;
+    }
+}

--- a/test/v1/BaseTest.t.sol
+++ b/test/v1/BaseTest.t.sol
@@ -41,8 +41,8 @@ abstract contract BaseTest is Test {
         }
     }
 
-    /// @dev this is a brute-force implementation of isOPStack from Constants.sol
-    /// we need this in tests because OP_STACK_L1_BLOCK_PREDEPLOY_ADDR doesn't exist on the test chain
+    /// @dev this is a brute-force implementation of isOPStack, and intentionally different from the one in Constants.sol.
+    /// We need this in tests because OP_STACK_L1_BLOCK_PREDEPLOY_ADDR doesn't exist on the test chain
     function _isOPStack(uint256 chainId) private view returns (bool) {
         uint256[6] memory OPChains = [
             BASE_MAINNET,

--- a/test/v1/LPNRegistryV1.t.sol
+++ b/test/v1/LPNRegistryV1.t.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.25;
 
-import {Test} from "forge-std/Test.sol";
+import {BaseTest} from "./BaseTest.t.sol";
 import {LPNRegistryV1TestHelper} from
     "../../src/v1/test_helpers/LPNRegistryV1TestHelper.sol";
 import {Initializable} from
@@ -18,7 +18,7 @@ import {QueryManager} from "../../src/v1/QueryManager.sol";
 import {IQueryManager} from "../../src/v1/interfaces/IQueryManager.sol";
 import {ILPNClientV1} from "../../src/v1/interfaces/ILPNClientV1.sol";
 
-contract LPNRegistryV1Test is Test {
+contract LPNRegistryV1Test is BaseTest {
     LPNRegistryV1TestHelper public registry;
     address public owner;
     address public stranger;
@@ -41,17 +41,17 @@ contract LPNRegistryV1Test is Test {
     uint256 constant TEST_END_BLOCK = 2000;
 
     bytes32[] responseData = [
-        keccak256(abi.encode(1)),
-        keccak256(abi.encode(2)),
-        keccak256(abi.encode(3)),
-        keccak256(abi.encode(4)),
-        keccak256(abi.encode(5)),
-        keccak256(abi.encode(6)),
-        keccak256(abi.encode(7)),
-        keccak256(abi.encode(8)),
-        keccak256(abi.encode(9)),
-        keccak256(abi.encode(10)),
-        keccak256(abi.encode(11))
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32()
     ];
 
     function setUp() public {
@@ -88,46 +88,50 @@ contract LPNRegistryV1Test is Test {
         // blockhash verification is enabled in tests
         assertTrue(registry.SUPPORTS_L1_BLOCKDATA());
         // Scroll mainnet
-        vm.chainId(534352);
-        LPNRegistryV1TestHelper scrollRegistry = new LPNRegistryV1TestHelper();
-        assertFalse(scrollRegistry.SUPPORTS_L1_BLOCKDATA());
-        assertEq(scrollRegistry.GAS_FEE(), 0.001 ether);
+        imitateChain(534352);
+        registry = new LPNRegistryV1TestHelper();
+        assertFalse(registry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(registry.GAS_FEE(), 0.001 ether);
         // Scroll testnet
-        vm.chainId(534351);
-        LPNRegistryV1TestHelper scrollTestnetRegistry =
-            new LPNRegistryV1TestHelper();
-        assertFalse(scrollTestnetRegistry.SUPPORTS_L1_BLOCKDATA());
-        assertEq(scrollTestnetRegistry.GAS_FEE(), 0.001 ether);
+        imitateChain(534351);
+        registry = new LPNRegistryV1TestHelper();
+        assertFalse(registry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(registry.GAS_FEE(), 0.001 ether);
         // Polygon zkEVM mainnet
-        vm.chainId(1101);
-        LPNRegistryV1TestHelper polygonZkRegistry =
-            new LPNRegistryV1TestHelper();
-        assertFalse(polygonZkRegistry.SUPPORTS_L1_BLOCKDATA());
-        assertEq(polygonZkRegistry.GAS_FEE(), 0.001 ether);
+        imitateChain(1101);
+        registry = new LPNRegistryV1TestHelper();
+        assertFalse(registry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(registry.GAS_FEE(), 0.001 ether);
         // Ethereum mainnet
-        vm.chainId(1);
-        LPNRegistryV1TestHelper ethMainnetRegistry =
-            new LPNRegistryV1TestHelper();
-        assertTrue(ethMainnetRegistry.SUPPORTS_L1_BLOCKDATA());
-        assertEq(ethMainnetRegistry.GAS_FEE(), 0.01 ether);
+        imitateChain(1);
+        registry = new LPNRegistryV1TestHelper();
+        assertTrue(registry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(registry.GAS_FEE(), 0.01 ether);
         // Ethereum Holesky testnet
-        vm.chainId(17000);
-        LPNRegistryV1TestHelper ethHoleskyRegistry =
-            new LPNRegistryV1TestHelper();
-        assertTrue(ethHoleskyRegistry.SUPPORTS_L1_BLOCKDATA());
-        assertEq(ethHoleskyRegistry.GAS_FEE(), 0.01 ether);
+        imitateChain(17000);
+        registry = new LPNRegistryV1TestHelper();
+        assertTrue(registry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(registry.GAS_FEE(), 0.01 ether);
         // Mantle mainnet
-        vm.chainId(5000);
-        LPNRegistryV1TestHelper mantleMainnetRegistry =
-            new LPNRegistryV1TestHelper();
-        assertTrue(mantleMainnetRegistry.SUPPORTS_L1_BLOCKDATA());
-        assertEq(mantleMainnetRegistry.GAS_FEE(), 4.0 ether);
+        imitateChain(5000);
+        registry = new LPNRegistryV1TestHelper();
+        assertTrue(registry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(registry.GAS_FEE(), 4.0 ether);
         // Mantle testnet
-        vm.chainId(5003);
-        LPNRegistryV1TestHelper mantleTestnetRegistry =
-            new LPNRegistryV1TestHelper();
-        assertTrue(mantleTestnetRegistry.SUPPORTS_L1_BLOCKDATA());
-        assertEq(mantleTestnetRegistry.GAS_FEE(), 4.0 ether);
+        imitateChain(5003);
+        registry = new LPNRegistryV1TestHelper();
+        assertTrue(registry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(registry.GAS_FEE(), 4.0 ether);
+        // Base mainnet
+        imitateChain(8453);
+        registry = new LPNRegistryV1TestHelper();
+        assertTrue(registry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(registry.GAS_FEE(), 0.001 ether);
+        // Base sepolia
+        imitateChain(84532);
+        registry = new LPNRegistryV1TestHelper();
+        assertTrue(registry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(registry.GAS_FEE(), 0.001 ether);
     }
 
     function test_initialize_duplicateAttempt_reverts() public {
@@ -327,5 +331,50 @@ contract LPNRegistryV1Test is Test {
         vm.prank(stranger);
         // vm.expectRevert(QueryManager.UnknownRequestID.selector); // DNE
         registry.respond(invalidRequestId, data, blockNumber);
+    }
+
+    function test_verifyBlockhash_success() public {
+        // Ethereum mainnet
+        imitateChain(1);
+        registry = new LPNRegistryV1TestHelper();
+        vm.expectRevert(QueryManager.BlockhashMismatch.selector);
+        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        // Scroll mainnet
+        imitateChain(534352);
+        registry = new LPNRegistryV1TestHelper();
+        registry.testVerifyBlockhash(randomBytes32(), randomBytes32()); // should not revert
+        // Scroll testnet
+        imitateChain(534351);
+        registry = new LPNRegistryV1TestHelper();
+        registry.testVerifyBlockhash(randomBytes32(), randomBytes32()); // should not revert
+        // Polygon zkEVM mainnet
+        imitateChain(1101);
+        registry = new LPNRegistryV1TestHelper();
+        registry.testVerifyBlockhash(randomBytes32(), randomBytes32()); // should not revert
+        // Ethereum Holesky testnet
+        imitateChain(17000);
+        registry = new LPNRegistryV1TestHelper();
+        vm.expectRevert(QueryManager.BlockhashMismatch.selector);
+        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        // Mantle mainnet
+        imitateChain(5000);
+        registry = new LPNRegistryV1TestHelper();
+        vm.expectRevert(QueryManager.BlockhashMismatch.selector);
+        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        // Mantle testnet
+        imitateChain(5003);
+        registry = new LPNRegistryV1TestHelper();
+        vm.expectRevert(QueryManager.BlockhashMismatch.selector);
+        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        // Base mainnet
+        imitateChain(8453);
+        registry = new LPNRegistryV1TestHelper();
+        vm.expectRevert(QueryManager.BlockhashMismatch.selector);
+        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        // Base sepolia
+        imitateChain(84532);
+        registry = new LPNRegistryV1TestHelper();
+        vm.expectRevert(QueryManager.BlockhashMismatch.selector);
+        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
     }
 }

--- a/test/v1/LPNRegistryV1.t.sol
+++ b/test/v1/LPNRegistryV1.t.sol
@@ -84,6 +84,35 @@ contract LPNRegistryV1Test is Test {
         );
     }
 
+    function test_constructor_disablesBlockhashVerification_success() public {
+        // blockhash verification is enabled in tests
+        assertTrue(registry.BLOCKHASH_VERIFICATION_ENABLED());
+        // Scroll mainnet
+        vm.chainId(534352);
+        LPNRegistryV1TestHelper scrollRegistry = new LPNRegistryV1TestHelper();
+        assertFalse(scrollRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+        // Scroll testnet
+        vm.chainId(534351);
+        LPNRegistryV1TestHelper scrollTestnetRegistry =
+            new LPNRegistryV1TestHelper();
+        assertFalse(scrollTestnetRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+        // Polygon zkEVM mainnet
+        vm.chainId(1101);
+        LPNRegistryV1TestHelper polygonZkRegistry =
+            new LPNRegistryV1TestHelper();
+        assertFalse(polygonZkRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+        // Ethereum mainnet
+        vm.chainId(1);
+        LPNRegistryV1TestHelper ethMainnetRegistry =
+            new LPNRegistryV1TestHelper();
+        assertTrue(ethMainnetRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+        // Ethereum Holesky testnet
+        vm.chainId(17000);
+        LPNRegistryV1TestHelper ethHoleskyRegistry =
+            new LPNRegistryV1TestHelper();
+        assertTrue(ethHoleskyRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+    }
+
     function test_initialize_duplicateAttempt_reverts() public {
         vm.expectRevert(Initializable.InvalidInitialization.selector);
         registry.initialize(stranger);

--- a/test/v1/LPNRegistryV1.t.sol
+++ b/test/v1/LPNRegistryV1.t.sol
@@ -91,26 +91,43 @@ contract LPNRegistryV1Test is Test {
         vm.chainId(534352);
         LPNRegistryV1TestHelper scrollRegistry = new LPNRegistryV1TestHelper();
         assertFalse(scrollRegistry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(scrollRegistry.GAS_FEE(), 0.001 ether);
         // Scroll testnet
         vm.chainId(534351);
         LPNRegistryV1TestHelper scrollTestnetRegistry =
             new LPNRegistryV1TestHelper();
         assertFalse(scrollTestnetRegistry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(scrollTestnetRegistry.GAS_FEE(), 0.001 ether);
         // Polygon zkEVM mainnet
         vm.chainId(1101);
         LPNRegistryV1TestHelper polygonZkRegistry =
             new LPNRegistryV1TestHelper();
         assertFalse(polygonZkRegistry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(polygonZkRegistry.GAS_FEE(), 0.001 ether);
         // Ethereum mainnet
         vm.chainId(1);
         LPNRegistryV1TestHelper ethMainnetRegistry =
             new LPNRegistryV1TestHelper();
         assertTrue(ethMainnetRegistry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(ethMainnetRegistry.GAS_FEE(), 0.01 ether);
         // Ethereum Holesky testnet
         vm.chainId(17000);
         LPNRegistryV1TestHelper ethHoleskyRegistry =
             new LPNRegistryV1TestHelper();
         assertTrue(ethHoleskyRegistry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(ethHoleskyRegistry.GAS_FEE(), 0.01 ether);
+        // Mantle mainnet
+        vm.chainId(5000);
+        LPNRegistryV1TestHelper mantleMainnetRegistry =
+            new LPNRegistryV1TestHelper();
+        assertTrue(mantleMainnetRegistry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(mantleMainnetRegistry.GAS_FEE(), 4.0 ether);
+        // Mantle testnet
+        vm.chainId(5003);
+        LPNRegistryV1TestHelper mantleTestnetRegistry =
+            new LPNRegistryV1TestHelper();
+        assertTrue(mantleTestnetRegistry.SUPPORTS_L1_BLOCKDATA());
+        assertEq(mantleTestnetRegistry.GAS_FEE(), 4.0 ether);
     }
 
     function test_initialize_duplicateAttempt_reverts() public {

--- a/test/v1/LPNRegistryV1.t.sol
+++ b/test/v1/LPNRegistryV1.t.sol
@@ -338,43 +338,43 @@ contract LPNRegistryV1Test is BaseTest {
         imitateChain(1);
         registry = new LPNRegistryV1TestHelper();
         vm.expectRevert(QueryManager.BlockhashMismatch.selector);
-        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        registry.verifyBlockhash(randomBytes32(), randomBytes32());
         // Scroll mainnet
         imitateChain(534352);
         registry = new LPNRegistryV1TestHelper();
-        registry.testVerifyBlockhash(randomBytes32(), randomBytes32()); // should not revert
+        registry.verifyBlockhash(randomBytes32(), randomBytes32()); // should not revert
         // Scroll testnet
         imitateChain(534351);
         registry = new LPNRegistryV1TestHelper();
-        registry.testVerifyBlockhash(randomBytes32(), randomBytes32()); // should not revert
+        registry.verifyBlockhash(randomBytes32(), randomBytes32()); // should not revert
         // Polygon zkEVM mainnet
         imitateChain(1101);
         registry = new LPNRegistryV1TestHelper();
-        registry.testVerifyBlockhash(randomBytes32(), randomBytes32()); // should not revert
+        registry.verifyBlockhash(randomBytes32(), randomBytes32()); // should not revert
         // Ethereum Holesky testnet
         imitateChain(17000);
         registry = new LPNRegistryV1TestHelper();
         vm.expectRevert(QueryManager.BlockhashMismatch.selector);
-        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        registry.verifyBlockhash(randomBytes32(), randomBytes32());
         // Mantle mainnet
         imitateChain(5000);
         registry = new LPNRegistryV1TestHelper();
         vm.expectRevert(QueryManager.BlockhashMismatch.selector);
-        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        registry.verifyBlockhash(randomBytes32(), randomBytes32());
         // Mantle testnet
         imitateChain(5003);
         registry = new LPNRegistryV1TestHelper();
         vm.expectRevert(QueryManager.BlockhashMismatch.selector);
-        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        registry.verifyBlockhash(randomBytes32(), randomBytes32());
         // Base mainnet
         imitateChain(8453);
         registry = new LPNRegistryV1TestHelper();
         vm.expectRevert(QueryManager.BlockhashMismatch.selector);
-        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        registry.verifyBlockhash(randomBytes32(), randomBytes32());
         // Base sepolia
         imitateChain(84532);
         registry = new LPNRegistryV1TestHelper();
         vm.expectRevert(QueryManager.BlockhashMismatch.selector);
-        registry.testVerifyBlockhash(randomBytes32(), randomBytes32());
+        registry.verifyBlockhash(randomBytes32(), randomBytes32());
     }
 }

--- a/test/v1/LPNRegistryV1.t.sol
+++ b/test/v1/LPNRegistryV1.t.sol
@@ -55,7 +55,7 @@ contract LPNRegistryV1Test is Test {
     ];
 
     function setUp() public {
-        vm.chainId(1); // pretend we're on ETH mainnet (must set before calling registry.gasFee())
+        vm.chainId(CHAIN_ID); // pretend we're on ETH mainnet
 
         owner = makeAddr("owner");
         stranger = makeAddr("stranger");
@@ -71,7 +71,7 @@ contract LPNRegistryV1Test is Test {
             bytes32(uint256(987)),
             bytes32(uint256(999))
         ];
-        FEE = registry.gasFee();
+        FEE = registry.GAS_FEE();
 
         vm.roll(TEST_START_BLOCK + registry.MAX_QUERY_RANGE() + 100); // fast-forward to ensure all queries in range are valid
 
@@ -84,33 +84,33 @@ contract LPNRegistryV1Test is Test {
         );
     }
 
-    function test_constructor_disablesBlockhashVerification_success() public {
+    function test_constructor_setsChainSpecificValues_success() public {
         // blockhash verification is enabled in tests
-        assertTrue(registry.BLOCKHASH_VERIFICATION_ENABLED());
+        assertTrue(registry.SUPPORTS_L1_BLOCKDATA());
         // Scroll mainnet
         vm.chainId(534352);
         LPNRegistryV1TestHelper scrollRegistry = new LPNRegistryV1TestHelper();
-        assertFalse(scrollRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+        assertFalse(scrollRegistry.SUPPORTS_L1_BLOCKDATA());
         // Scroll testnet
         vm.chainId(534351);
         LPNRegistryV1TestHelper scrollTestnetRegistry =
             new LPNRegistryV1TestHelper();
-        assertFalse(scrollTestnetRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+        assertFalse(scrollTestnetRegistry.SUPPORTS_L1_BLOCKDATA());
         // Polygon zkEVM mainnet
         vm.chainId(1101);
         LPNRegistryV1TestHelper polygonZkRegistry =
             new LPNRegistryV1TestHelper();
-        assertFalse(polygonZkRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+        assertFalse(polygonZkRegistry.SUPPORTS_L1_BLOCKDATA());
         // Ethereum mainnet
         vm.chainId(1);
         LPNRegistryV1TestHelper ethMainnetRegistry =
             new LPNRegistryV1TestHelper();
-        assertTrue(ethMainnetRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+        assertTrue(ethMainnetRegistry.SUPPORTS_L1_BLOCKDATA());
         // Ethereum Holesky testnet
         vm.chainId(17000);
         LPNRegistryV1TestHelper ethHoleskyRegistry =
             new LPNRegistryV1TestHelper();
-        assertTrue(ethHoleskyRegistry.BLOCKHASH_VERIFICATION_ENABLED());
+        assertTrue(ethHoleskyRegistry.SUPPORTS_L1_BLOCKDATA());
     }
 
     function test_initialize_duplicateAttempt_reverts() public {


### PR DESCRIPTION
This PR does the following:
* Adds support for the Scroll blockchain (mainnet & testnet) ([ticket](https://linear.app/lagrange/issue/LAG-161/adapt-the-query-contract-to-scroll))
* Removes the last bit of codegen from the `copy-verifier.sh` script
	* Instead, we overwrite the `verifyBlockhash()` function from `Groth16VerifierExtension` in `QueryManager`
* Refactors the `getGasFee()` function so that the fee is set once at deployment rather than wasting gas to check the chainID every time.
* adds a `supportsL1BlockData()` function that skips reading blocknumber and blockhash if the contract is deployed to scroll or polygon zk chain