### PR TITLE
simplify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,4 @@ WORKDIR /app
 
 COPY . .
 
-# Make the script executable
-RUN chmod +x /app/entrypoint.sh
-
-# Set the entrypoint
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["make"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-cd /
-git clone https://github.com/Lagrange-Labs/mapreduce-plonky2.git
-cd /app
-make DeployLPNRegistryV1_dev-0


### PR DESCRIPTION
This PR does the following:
  * Changes the entrypoint in the `Dockerfile` to `make`, so that any make command can be executed using this image.
  * Gets rid of the entrypoint script.
    * Note, the `git clone https://github.com/Lagrange-Labs/mapreduce-plonky2.git` step is no longer necessary for deploying after making [this change.](https://github.com/Lagrange-Labs/lagrange-lpn-contracts/blob/664e2ce28654b830d8f3fa49a763abf01d8ab44b/script/util/copy-verifier.sh#L10)