### PR TITLE
Fix decimals bug in balance checker

### DIFF
--- a/script/CheckDeploymentKeyBalances.s.sol
+++ b/script/CheckDeploymentKeyBalances.s.sol
@@ -54,7 +54,9 @@ contract CheckDeploymentKeyBalances is
                     " (",
                     vm.toString(balance / 1 ether),
                     ".",
-                    vm.toString(((balance % 1 ether) * 1000) / 1 ether), // add 3 decimals
+                    vm.toString((((balance % 1 ether) * 10) / 1 ether) % 10), // add 3 decimal places
+                    vm.toString((((balance % 1 ether) * 100) / 1 ether) % 10),
+                    vm.toString((((balance % 1 ether) * 1000) / 1 ether) % 10),
                     " ETH)"
                 );
             } catch {


### PR DESCRIPTION
There was a bug in the balance checker script where it wasn't including leading 0s when printing balances

Before:
```
Checking balances for environment: test

  Address: 0x48211415Fc3e48b1aC5389fdDD4c1755783F6199
  Minimum balance: 1000000000000000000 WEI
  ----------------------------------------
  ...
  fraxtal_testnet: LOW (0.9 ETH)
```

After:
```
Checking balances for environment: test

  Address: 0x48211415Fc3e48b1aC5389fdDD4c1755783F6199
  Minimum balance: 1000000000000000000 WEI
  ----------------------------------------
  ...
  fraxtal_testnet: LOW (0.009 ETH)
```