### PR TITLE
Fix compiler warning due to unused function parameter

### DIFF
--- a/src/v1/QueryManager.sol
+++ b/src/v1/QueryManager.sol
@@ -170,7 +170,7 @@ abstract contract QueryManager is IQueryManager, Groth16VerifierExtension {
     function respond(
         uint256 requestId_,
         bytes32[] calldata data,
-        uint256 blockNumber // TODO - remove
+        uint256 // TODO - remove
     ) external {
         QueryRequest memory query = requests[requestId_];
         delete requests[requestId_];


### PR DESCRIPTION
This PR just removes an unused parameter name to suppress the compiler error. In the future we should restructure the function entirely.