### PR TITLE
Fallback to verifier.sol in copy-verifier script

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -22,12 +22,12 @@ line_length = 80
 # used for local development
 anvil = "http://localhost:8545"
 # used for `dev` environment
-dev-0 = "https://holesky.gateway.tenderly.co"
-dev-1 = "https://holesky.gateway.tenderly.co"
-dev-2 = "https://holesky.gateway.tenderly.co"
-dev-3 = "https://holesky.gateway.tenderly.co"
+dev-0 = "https://ethereum-holesky-rpc.publicnode.com"
+dev-1 = "https://ethereum-holesky-rpc.publicnode.com"
+dev-2 = "https://ethereum-holesky-rpc.publicnode.com"
+dev-3 = "https://ethereum-holesky-rpc.publicnode.com"
 # used for `test` environment
-holesky = "https://holesky.gateway.tenderly.co"
+holesky = "https://ethereum-holesky-rpc.publicnode.com"
 sepolia = "https://ethereum-sepolia-rpc.publicnode.com"
 base_sepolia = "https://base-sepolia-rpc.publicnode.com"
 fraxtal_testnet = "https://rpc.testnet.frax.com"

--- a/script/util/copy-verifier.sh
+++ b/script/util/copy-verifier.sh
@@ -41,7 +41,14 @@ VERIFIER_EXTENSION_FILE=$VERIFIER_FOLDER/Groth16VerifierExtension.sol.ignore
 
 mkdir -p $VERIFIER_FOLDER
 
-wget -O $VERIFIER_FILE $VERIFIER_SOL_URL
+# TODO - once all environments have upgraded to latest MRP2, we will no longer need to support
+# both Verifier.sol and verifier.sol and can standardize on the uppercase version.
+wget -O $VERIFIER_FILE $VERIFIER_SOL_URL || {
+    # If it fails, try with lowercase v
+    echo "Failed to download Verifier.sol, falling back to verifier.sol"
+    VERIFIER_SOL_URL="${VERIFIER_SOL_URL/Verifier.sol/verifier.sol}"
+    wget -O $VERIFIER_FILE $VERIFIER_SOL_URL
+}
 wget -O $VERIFIER_EXTENSION_FILE $VERIFIER_EXTENSION_URL
 
 cp $VERIFIER_EXTENSION_FILE ./src/v1/Groth16VerifierExtension.sol


### PR DESCRIPTION
This PR adds a temporary fallback in the `copy-verifier` script so that all environments can utilize the contracts-CD pipeline, even those working on older versions of mp2. This a benign, temporary fallback that we can remove at a later date once all environments have upgraded.