### PR TITLE
Connect DBManager & QueryExecutor; validate query in request()

### DIFF
--- a/src/v2/DatabaseManager.sol
+++ b/src/v2/DatabaseManager.sol
@@ -103,4 +103,11 @@ contract DatabaseManager is
         queries[hash] = tableHash;
         emit NewQueryRegistration(hash, tableHash, sql);
     }
+
+    /// @notice Checks if a query is queryable
+    /// @param hash The hash of the query
+    /// @return True if the query is queryable, false otherwise
+    function isQueryActive(bytes32 hash) public view returns (bool) {
+        return tables[queries[hash]];
+    }
 }

--- a/test/v2/BaseTest.t.sol
+++ b/test/v2/BaseTest.t.sol
@@ -41,6 +41,13 @@ abstract contract BaseTest is Test {
         }
     }
 
+    /// @notice Creates a labeled address with non-empty bytecode for use as a contract mock
+    function makeMock(string memory name) internal returns (address) {
+        address mock = makeAddr(name);
+        vm.etch(mock, hex"00");
+        return mock;
+    }
+
     /// @dev this is a brute-force implementation of isOPStack, and intentionally different from the one in Constants.sol.
     /// We need this in tests because OP_STACK_L1_BLOCK_PREDEPLOY_ADDR doesn't exist on the test chain
     function _isOPStack(uint256 chainId) private pure returns (bool) {

--- a/test/v2/DatabaseManager.t.sol
+++ b/test/v2/DatabaseManager.t.sol
@@ -148,4 +148,33 @@ contract DatabaseManagerTest is BaseTest {
 
         vm.stopPrank();
     }
+
+    function test_IsQueryActive() public {
+        vm.startPrank(owner);
+
+        // Register table and query
+        dbManager.registerTable(
+            TEST_TABLE_HASH, address(0x123), 1, 100, "test_table", TEST_SQL
+        );
+        dbManager.registerQuery(TEST_QUERY_HASH, TEST_TABLE_HASH, TEST_SQL);
+
+        // Query should be active
+        assertTrue(dbManager.isQueryActive(TEST_QUERY_HASH));
+
+        // Delete table
+        dbManager.deleteTable(TEST_TABLE_HASH);
+
+        // Query should no longer be active
+        assertFalse(dbManager.isQueryActive(TEST_QUERY_HASH));
+
+        // Re-activate the table
+        dbManager.registerTable(
+            TEST_TABLE_HASH, address(0x123), 1, 100, "test_table", TEST_SQL
+        );
+
+        // Query should now be active again
+        assertTrue(dbManager.isQueryActive(TEST_QUERY_HASH));
+
+        vm.stopPrank();
+    }
 }

--- a/test/v2/test_helpers/QueryExecutorTestHelper.sol
+++ b/test/v2/test_helpers/QueryExecutorTestHelper.sol
@@ -6,13 +6,21 @@ import {
     QueryOutput,
     QueryInput
 } from "../../../src/v2/Groth16VerifierExtension.sol";
+import {DatabaseManager} from "../../../src/v2/DatabaseManager.sol";
+import {FeeCollector} from "../../../src/v2/FeeCollector.sol";
 
 /// @title QueryExecutorTestHelper
 /// @notice A test helper contract where groth-16 verification is skipped
 /// @dev XXX testing purposes only XXX
 /// @dev we want to mock as few functions as possible here to get us as close to the real deal as possible in testing
 contract QueryExecutorTestHelper is QueryExecutor {
-    constructor(address _router) QueryExecutor(_router) {}
+    constructor(address _router, address _dbManager, address _feeCollector)
+        QueryExecutor(
+            _router,
+            DatabaseManager(_dbManager),
+            FeeCollector(payable(_feeCollector))
+        )
+    {}
 
     function processQuery(bytes32[] calldata data, QueryInput memory query)
         public


### PR DESCRIPTION
This PR does the following:
* Makes DBManager and FeeCollector deployment dependancies of the QueryExecutor
* Adds an `isQueryActive()` function to the DBManager that signals if a query is valid or not
* Adds a check to the `request()` function for query validity - this will ensure queries are only being made on tables that we actually support