### PR TITLE
Forward fee from QueryExecutor to FeeCollector

### DIFF
--- a/src/v2/QueryExecutor.sol
+++ b/src/v2/QueryExecutor.sol
@@ -90,6 +90,9 @@ contract QueryExecutor is
     /// @notice Error thrown when a non-router address calls a router-only function
     error OnlyRouter();
 
+    /// @notice Error thrown when a transfer fails.
+    error TransferFailed();
+
     modifier requireGasFee() {
         if (msg.value < GAS_FEE) {
             revert InsufficientGasFee();
@@ -198,6 +201,13 @@ contract QueryExecutor is
             }),
             client: client
         });
+
+        // Forward fee to fee collector
+        (bool success,) =
+            payable(address(feeCollector)).call{value: msg.value}("");
+        if (!success) {
+            revert TransferFailed();
+        }
 
         return requestId;
     }

--- a/test/v2/QueryExecutor.t.sol
+++ b/test/v2/QueryExecutor.t.sol
@@ -152,6 +152,11 @@ contract QueryExecutorTest is BaseTest {
         address encodedAddress = address(bytes20(bytes32(id) << (8 * 2)));
         assertEq(address(executor), encodedAddress);
 
+        // Entire fee should be forwarded to fee collector
+        assertEq(feeCollector.balance, FEE);
+        assertEq(address(executor).balance, 0);
+
+        // Make a 2nd request
         vm.prank(router);
         uint256 id2 = executor.request{value: FEE}(
             client,


### PR DESCRIPTION
As part of the new modular design, we want all fees collected within the system to be pushed to the FeeCollector contract