### PR TITLE
Switch DB Manager access control to ownership

### DIFF
--- a/src/v2/DatabaseManager.sol
+++ b/src/v2/DatabaseManager.sol
@@ -2,24 +2,21 @@
 pragma solidity 0.8.25;
 
 import {IVersioned} from "../interfaces/IVersioned.sol";
-import {AccessControlUpgradeable} from
-    "@openzeppelin-contracts-upgradeable-5.2.0/access/AccessControlUpgradeable.sol";
+import {Ownable2StepUpgradeable} from
+    "@openzeppelin-contracts-upgradeable-5.2.0/access/Ownable2StepUpgradeable.sol";
 import {Initializable} from
     "@openzeppelin-contracts-upgradeable-5.2.0/proxy/utils/Initializable.sol";
 
 /// @title DatabaseManager
 /// @notice Manages the registration of tables and queries for the system
 /// @dev This contract is upgradable
-/// @dev AccessControl is used instead of Ownable for better upgradability in case future roles are required
 contract DatabaseManager is
     Initializable,
-    AccessControlUpgradeable,
+    Ownable2StepUpgradeable,
     IVersioned
 {
     /// @notice The semantic version of the contract
     string public constant version = "1.0.0";
-
-    bytes32 private constant OWNER_ROLE = keccak256("OWNER_ROLE");
 
     /// @notice Mapping to track registered tables
     mapping(bytes32 tableHash => bool registered) public tables;
@@ -58,8 +55,8 @@ contract DatabaseManager is
 
     /// @notice Initializes the contract
     function initialize(address initialOwner) public initializer {
-        __AccessControl_init();
-        _grantRole(OWNER_ROLE, initialOwner);
+        __Ownable2Step_init();
+        _transferOwnership(initialOwner);
     }
 
     /// @notice Registers a new table
@@ -76,7 +73,7 @@ contract DatabaseManager is
         uint256 genesisBlock,
         string calldata name,
         string calldata schema
-    ) external onlyRole(OWNER_ROLE) {
+    ) external onlyOwner {
         if (tables[hash]) {
             revert TableAlreadyRegistered();
         }
@@ -88,7 +85,7 @@ contract DatabaseManager is
 
     /// @notice Deletes a registered table
     /// @param hash The hash of the table to delete
-    function deleteTable(bytes32 hash) external onlyRole(OWNER_ROLE) {
+    function deleteTable(bytes32 hash) external onlyOwner {
         delete tables[hash];
         emit TableDeleted(hash);
     }

--- a/test/v2/DatabaseManager.t.sol
+++ b/test/v2/DatabaseManager.t.sol
@@ -4,11 +4,12 @@ pragma solidity ^0.8.0;
 import {DatabaseManager} from "../../src/v2/DatabaseManager.sol";
 import {BaseTest} from "./BaseTest.t.sol";
 
-import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {Initializable} from
     "@openzeppelin-contracts-upgradeable-5.2.0/proxy/utils/Initializable.sol";
 import {TransparentUpgradeableProxy} from
     "@openzeppelin-contracts-5.2.0/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {OwnableUpgradeable} from
+    "@openzeppelin-contracts-upgradeable-5.2.0/access/OwnableUpgradeable.sol";
 
 contract DatabaseManagerTest is BaseTest {
     DatabaseManager public implementation;
@@ -41,8 +42,7 @@ contract DatabaseManagerTest is BaseTest {
     }
 
     function test_Initialize() public view {
-        assertTrue(dbManager.hasRole(keccak256("OWNER_ROLE"), owner));
-        assertFalse(dbManager.hasRole(keccak256("OWNER_ROLE"), stranger));
+        assertEq(dbManager.owner(), owner);
     }
 
     function test_Initialize_RevertsIf_DuplicateAttempt() public {
@@ -79,9 +79,7 @@ contract DatabaseManagerTest is BaseTest {
         vm.prank(stranger);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector,
-                stranger,
-                keccak256("OWNER_ROLE")
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector, stranger
             )
         );
         dbManager.registerTable(
@@ -132,9 +130,7 @@ contract DatabaseManagerTest is BaseTest {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector,
-                stranger,
-                keccak256("OWNER_ROLE")
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector, stranger
             )
         );
         dbManager.deleteTable(TEST_TABLE_HASH);


### PR DESCRIPTION
Changing the ownership model from [role based access control](https://docs.openzeppelin.com/contracts/2.x/access-control#role-based-access-control) to [ownership](https://docs.openzeppelin.com/contracts/2.x/access-control#ownership-and-ownable) because I don't see the need for alternative roles in the near future, and this keeps all of our ownership models consistent across the stack.

More context: I had previously thought RBAC might be better on some upgradeable contracts as a way to future-proof the contract against needing to add this functionality later. But I think the uniformity of a single ownership model outweighs the "future-proofing" benefits. We can add RBAC at a later date if needed, but I doubt it will be needed any time soon.